### PR TITLE
Retropie gpio button support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See the table below for feature comparison between Pi1541 and C64 emulator modes
 | Activity led         | supported            | not supported      |
 | Disk loading sounds  | supported            | not supported      |
 | LED screen           | supported            | supported          |
-| Front panel buttons  | supported            | not supported      |
+| Front panel buttons  | supported            | supported          |
 | Disk images via USB  | supported            | not supported      |
 | HDMI output          | supported            | supported          |
 | USB joysticks        | -                    | supported          |
@@ -111,27 +111,19 @@ End result should look like this:
 
 #### Adding support for front panel buttons
 
-Install GPIO driver:
+Install [https://github.com/mholgatem/GPIOnext](GPIONext) in retropie terminal:
 
-- RetroPie Setup > Manage Packages > Manage Driver Packages > **mkarcadejoystick**
+    cd ~
+    git clone https://github.com/mholgatem/GPIOnext.git
+    bash GPIOnext/install.sh
 
-Reboot. Ensure the module is autoloaded:
+Configure the buttons with wizard (as keyboard as controller, depending what you prefer)
 
-    sudo nano /etc/modules
+Run as background deamon:
 
-Make sure it contains line:
+    gpionext start
 
-    mk_arcade_joystick_rpi
-
-Open config file:
-
-    sudo nano /etc/modprobe.d/mk_arcade_joystick.conf
-
-Add custom gpio map (param order: Y-,Y+,X-,X+,start,select,a,b,tr,y,x,tl):
-
-    options mk_arcade_joystick_rpi map=5 gpio=16,15,7,29,-1,-1,13,-1,-1,-1,-1,-1   
-
-Reboot
+Reboot. When opening RetroPie, you should be able to use the buttons as a given controller
 
 Pinout comparison table for reference:
 
@@ -142,7 +134,6 @@ Pinout comparison table for reference:
 | Switch 3        | pin 16   | next disk / move down   | joystick down     |
 | Switch 4        | pin 07   | exit folder             | joystick left     |
 | Switch 5        | pin 29   | insert disk             | joystick right    |
-
 
 ## License and Credits
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@
 
 See the table below for feature comparison between Pi1541 and C64 emulator modes.
 
-| Feature              | Pi1541 Mode        | C64 Emulator Mode  |
-|----------------------|--------------------|--------------------|
-| Power led            | supported          | supported          |
-| Activity led         | supported          | not supported      |
-| Disk loading sounds  | supported          | not supported      |
-| LED screen           | supported          | supported          |
-| Front panel buttons  | supported          | not supported      |
-| Disk images via USB  | supported          | not supported      |
-| HDMI output          | supported          | supported          |
-| USB joysticks        | -                  | supported          |
-| Bluetooth joysticks  | -                  | supported          |
+| Feature              | 1541 Disk Drive Mode | C64 Emulator Mode  |
+|----------------------|----------------------|--------------------|
+| Power led            | supported            | supported          |
+| Activity led         | supported            | not supported      |
+| Disk loading sounds  | supported            | not supported      |
+| LED screen           | supported            | supported          |
+| Front panel buttons  | supported            | not supported      |
+| Disk images via USB  | supported            | not supported      |
+| HDMI output          | supported            | supported          |
+| USB joysticks        | -                    | supported          |
+| Bluetooth joysticks  | -                    | supported          |
 
 ## Building Instructions
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JCR-1541-II-1 - A Hybrid Disk Drive and C64 Emulator in Commodore 1541-II Form Factor
+# JCR-1541-II-1 - A Hybrid 1541 Disk Drive and C64 Emulator in Classic Form Factor
 
 ![](./images/20200214-1.jpg)
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,26 @@ End result should look like this:
 
 ![](./images/20200220-1.jpg)
 
+#### Adding support for front panel buttons
+
+Install and configure GPIO module library:
+
+https://github.com/RetroPie/RetroPie-Setup/wiki/GPIO-Modules
+
+Pins:
+
+| Label           | GPIO pin | Pi1541 function         | RetroPie function |
+|-----------------|----------|-------------------------|-------------------|
+| Switch 1        | pin 13   | reset / select          | joystick fire     |
+| Switch 2        | pin 15   | previous disk / move up | joystick up       |
+| Switch 3        | pin 16   | next disk / move down   | joystick down     |
+| Switch 4        | pin 07   | exit folder             | joystick left     |
+| Switch 5        | pin 29   | insert disk             | joystick right    |
+
+TODO:
+
+- How to configure
+
 ## License and Credits
 
 **This project is provided "as is", without warranty of any kind.**

--- a/README.md
+++ b/README.md
@@ -111,11 +111,29 @@ End result should look like this:
 
 #### Adding support for front panel buttons
 
-Install and configure GPIO module library:
+Install GPIO driver:
 
-https://github.com/RetroPie/RetroPie-Setup/wiki/GPIO-Modules
+- RetroPie Setup > Manage Packages > Manage Driver Packages > **mkarcadejoystick**
 
-Pins:
+Reboot. Ensure the module is autoloaded:
+
+    sudo nano /etc/modules
+
+Make sure it contains line:
+
+    mk_arcade_joystick_rpi
+
+Open config file:
+
+    sudo nano /etc/modprobe.d/mk_arcade_joystick.conf
+
+Add custom gpio map (param order: Y-,Y+,X-,X+,start,select,a,b,tr,y,x,tl):
+
+    options mk_arcade_joystick_rpi map=5 gpio=16,15,7,29,-1,-1,13,-1,-1,-1,-1,-1   
+
+Reboot
+
+Pinout comparison table for reference:
 
 | Label           | GPIO pin | Pi1541 function         | RetroPie function |
 |-----------------|----------|-------------------------|-------------------|
@@ -125,9 +143,6 @@ Pins:
 | Switch 4        | pin 07   | exit folder             | joystick left     |
 | Switch 5        | pin 29   | insert disk             | joystick right    |
 
-TODO:
-
-- How to configure
 
 ## License and Credits
 


### PR DESCRIPTION
**Not completed**

Attempting to add gpio button support to retropie, with the following challenges:

- Requires `mk_arcade_joystick_rpi` version containing custom gpio mapping support. This version must be currently built from master of https://github.com/recalbox/mk_arcade_joystick_rpi
- Compilation fails in Retropie 4.14.98-v7+
- This should be first resolved

Another issue:

- GPIO buttons should not be the only way to use a given controller. For instance, if GPIO buttons are mapped to joystick 1, we should allow users to also attach another device as joystick 1. I am not sure how this can be resolved